### PR TITLE
[FiX] [BVFH-106] JWT 서명 키 생성 로직 수정

### DIFF
--- a/src/main/java/com/chalnakchalnak/authservice/adapter/in/web/presentation/AuthController.java
+++ b/src/main/java/com/chalnakchalnak/authservice/adapter/in/web/presentation/AuthController.java
@@ -11,6 +11,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -119,4 +122,5 @@ public class AuthController {
                 authVoMapper.toResetPasswordRequestDto(resetPasswordRequestVo)
         );
     }
+
 }

--- a/src/main/java/com/chalnakchalnak/authservice/adapter/out/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/chalnakchalnak/authservice/adapter/out/security/provider/JwtTokenProvider.java
@@ -124,8 +124,8 @@ public class JwtTokenProvider {
      */
     public Key getSignKey() {
         String secret = Objects.requireNonNull(env.getProperty("JWT.secret-key"));
-        byte[] decodedKey = Base64.getDecoder().decode(secret);
+//        byte[] decodedKey = Base64.getDecoder().decode(secret);
 
-        return Keys.hmacShaKeyFor(decodedKey);
+        return Keys.hmacShaKeyFor(secret.getBytes());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,7 @@ coolsms:
   domain: https://api.coolsms.co.kr
 
 JWT:
-  secret-key:  ${JWT_SECRET}
+  secret-key: ${JWT_SECRET}
   token:
     access-expire-time: 604800
     refresh-expire-time: 1209600


### PR DESCRIPTION
## 🔗 관련 JIRA KEY

> PR 제목 앞에 Jira 키를 포함해주세요  
> 예: `[FEAT] PMEL-200 - 기능 제목`

BVFH-106]

## 📝 작업 내용 요약

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- Kong에서 Base64 Decoding 불가 이슈로 시크릿 키를 평문 바이트 배열로 생성하여 서명 키로 사용하도록 변경

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우, 전/후 비교 스크린샷 또는 동작 GIF를 첨부해주세요.

--- 해당없음

## 💬 리뷰 포인트 (선택)

> 리뷰어가 중점적으로 확인했으면 하는 부분이 있다면 작성해주세요.

- 메서드/변수 네이밍 개선 제안
- 특정 로직의 예외 처리 방식 검토 요청

---

## ✅ 체크리스트

- [x] PR 제목에 Jira Key 포함했나요? (`PMEL-123` 등)
- [x] 로컬 테스트를 완료했나요?
- [x] 리뷰어를 지정했나요?
